### PR TITLE
fix scipy import error and build syntax errors

### DIFF
--- a/PyQtMapManager/main.py
+++ b/PyQtMapManager/main.py
@@ -42,7 +42,7 @@ if __name__ == '__main__':
 
     if 0:
         defaultMap = '/Users/cudmore/Desktop/data/rr30a/rr30a.txt'
-        print 'loading map:', defaultMap
+        print('loading map:', defaultMap)
         m = mmMap(filePath=defaultMap)
 
         import pymapmanager
@@ -57,13 +57,13 @@ if __name__ == '__main__':
         # path = '/Volumes/fourt/MapManagerData/richard/Nancy/'
 
         stacks = mmStackPool(path)
-        print stacks
+        print(stacks)
 
         for stack in stacks:
-            print stack
+            print(stack)
 
         images = stacks.stacks[1].loadStackImages(channel=1)
-        print images.shape
+        print(images.shape)
 
     if 0:
         import matplotlib.pyplot as plt
@@ -72,10 +72,10 @@ if __name__ == '__main__':
         from pymapmanager.mmUtil import newplotdict
 
         defaultMap = '/Users/cudmore/Desktop/data/rr30a/rr30a.txt'
-        print 'loading map:', defaultMap
+        print('loading map:', defaultMap)
         m = mmMap(filePath=defaultMap)
 
-        print m.stacks[0].stackdb
+        print(m.stacks[0].stackdb)
 
         plotDict = newplotdict()
         plotDict['segmentid'] = [0]

--- a/PyQtMapManager/mmApp.py
+++ b/PyQtMapManager/mmApp.py
@@ -210,21 +210,21 @@ class mmApplicationWindow(QtGui.QMainWindow):
             #defaultMap = '/Volumes/fourt/MapManager_Data/stroke1/stroke1.txt'
             if not os.path.isfile(defaultMap):
                 raise IOError(ENOENT, 'mmApp did not find defaultMap:', defaultMap)
-            print 'loading default map:', defaultMap
+            print('loading default map:', defaultMap)
             self.loadMap(defaultMap)
             """
             defaultMap = '/Users/cudmore/Desktop/data/rr58c/rr58c.txt'
             if os.path.isfile(defaultMap):
-                print 'loading default map:', defaultMap
+                print('loading default map:', defaultMap
                 self.loadMap(defaultMap)
             else:
-                print 'error loading map:', defaultMap
+                print('error loading map:', defaultMap
             """
         if 0:
             defaultMap = '/Users/cudmore/Dropbox/MapManagerData/server/public/amit1/amit1.txt'
             if not os.path.isfile(defaultMap):
                 raise IOError(ENOENT, 'mmApp did not find defaultMap:', defaultMap)
-            print 'loading default map:', defaultMap
+            print('loading default map:', defaultMap)
             self.loadMap(defaultMap)
         # load from online repository
         if 1:
@@ -287,7 +287,7 @@ class mmApplicationWindow(QtGui.QMainWindow):
 
     def dragEnterEvent(self, event):
         """Changes the look of the main window when a file/folder is dragged over the window."""
-        print event.mimeData()
+        print(event.mimeData())
         if event.mimeData().hasFormat("text/uri-list"):
             event.acceptProposedAction()
         event.acceptProposedAction()
@@ -298,10 +298,10 @@ class mmApplicationWindow(QtGui.QMainWindow):
         if urls:
             filename = urls[0].toLocalFile()
             if filename:
-                print 'todo: implement drag and drop of folders, maps, and stacks, filename:', filename
+                print('todo: implement drag and drop of folders, maps, and stacks, filename:', filename)
 
     # def mainToolbar_callback(self, a):
-    #    print 'mainToolbar_callback:', a
+    #    print('mainToolbar_callback:', a
 
     def loadMap(self, path=None, urlmap=None):
         """Load a mmMap into application. Application keeps 'maps', a list of maps."""
@@ -376,27 +376,27 @@ class mmApplicationWindow(QtGui.QMainWindow):
         self.xstatListWidget.setCurrentRow(2)
 
     def toolbarButton_callback(self, buttonID):
-        print 'toolbarButton_callback:', buttonID
+        print('toolbarButton_callback:', buttonID)
         if buttonID == 'loadMapButton':
             self.loadMap()
 
     def map_list_changed(self, curr, prev):
         # (curr,prev) are QListWidgetItem
-        print 'ApplicationWindow.map_list_changed', curr
-        print '   currentRow:', self.mapListWidget.currentRow()
-        print '   ', self.mapListWidget.currentItem().text()
+        print('ApplicationWindow.map_list_changed', curr)
+        print('   currentRow:', self.mapListWidget.currentRow())
+        print('   ', self.mapListWidget.currentItem().text())
 
     def sess_list_changed(self, curr, prev):
         # (curr,prev) are QListWidgetItem
-        print 'ApplicationWindow.sess_list_changed', curr
-        print '   currentRow:', self.sessListWidget.currentRow()
-        print '   ', self.sessListWidget.currentItem().text()
+        print('ApplicationWindow.sess_list_changed', curr)
+        print('   currentRow:', self.sessListWidget.currentRow())
+        print('   ', self.sessListWidget.currentItem().text())
 
     def seg_list_changed(self, curr, prev):
         # (curr,prev) are QListWidgetItem
-        print 'ApplicationWindow.seg_list_changed', curr
-        print '   currentRow:', self.segListWidget.currentRow()
-        print '   ', self.segListWidget.currentItem().text()
+        print('ApplicationWindow.seg_list_changed', curr)
+        print('   currentRow:', self.segListWidget.currentRow())
+        print('   ', self.segListWidget.currentItem().text())
 
     def getState(self):
         """Capture the full state of the interface including selected: map, session, segment, ystat, xstat."""
@@ -441,7 +441,7 @@ class mmApplicationWindow(QtGui.QMainWindow):
         """
 
     def plotStackButton_callback(self):
-        print 'ApplicationWindow.plotStackButton_callback()'
+        print('ApplicationWindow.plotStackButton_callback()')
 
         # todo: add to list of open windows self._windows
 
@@ -454,7 +454,7 @@ class mmApplicationWindow(QtGui.QMainWindow):
         plotwindow.show()
 
     def plotMapButton_callback(self):
-        print 'ApplicationWindow.plotMapButton_callback()'
+        print('ApplicationWindow.plotMapButton_callback()')
 
         # todo: add to list of open windows self._windows
 
@@ -490,7 +490,7 @@ class mmApplicationWindow(QtGui.QMainWindow):
         plotwindow.show()
 
     def plotStackImageButton_callback(self):
-        print 'ApplicationWindow.plotStackImageButton_callback()'
+        print('ApplicationWindow.plotStackImageButton_callback()')
 
         # todo: add to list of open windows self._windows
 

--- a/PyQtMapManager/mmCanvas.py
+++ b/PyQtMapManager/mmCanvas.py
@@ -66,7 +66,7 @@ class mmCanvas(FigureCanvas):
         pass
 
     def onkey(self, event):
-        print 'mmCanvas.onkey()', event.key
+        print('mmCanvas.onkey()', event.key)
         key = event.key
 
         #
@@ -106,7 +106,7 @@ class mmCanvas(FigureCanvas):
             self.draw()
 
         elif key == 'esc':
-            print 'esc needs to cancel spine selection'
+            print('esc needs to cancel spine selection')
 
     def togglelines(self, onoff=None):
         """Toggle lines connecting annotations between timepoint. Be carefull here on repeatedly plot these lines"""
@@ -115,19 +115,19 @@ class mmCanvas(FigureCanvas):
         """Turn dynamics marker color on and off"""
 
     def onclick(self, event):
-        print 'mmCanvas.onclick()', event.button, event.x, event.y, event.xdata, event.ydata
+        print('mmCanvas.onclick()', event.button, event.x, event.y, event.xdata, event.ydata)
 
     def onscroll(self, event):
-        print 'mmCanvas.onscroll()'
+        print('mmCanvas.onscroll()')
 
     def receiveevent(self, event):
-        print 'mmCanvas.receiveevent()', event.type
+        print('mmCanvas.receiveevent()', event.type)
 
     def onpick(self, event):
         """
         Respond to clicks in a map, stack, and image plot.
         """
-        print 'mmCanvas.onpick()', event.ind
+        print('mmCanvas.onpick()', event.ind)
 
 class mmMapPlotCanvas(mmCanvas):
     """Plot and interact with a plot of stack values across a map"""
@@ -200,7 +200,7 @@ class mmMapPlotCanvas(mmCanvas):
         self.myScatterPlot.set_color(cMatrix)
 
     def receiveevent(self, event):
-        print 'mmMapPlotCanvas.receiveevent()', event.type
+        print('mmMapPlotCanvas.receiveevent()', event.type)
         if event.map != self.map:
             return
         if event.type == 'spine selection':
@@ -219,7 +219,7 @@ class mmMapPlotCanvas(mmCanvas):
                 self.draw()
 
     def onkey(self, event):
-        print 'MyStaticMplCanvas.onkey()', event.key
+        print('MyStaticMplCanvas.onkey()', event.key)
         super(mmMapPlotCanvas, self).onkey(event)
 
     def onpick(self, event):
@@ -231,7 +231,7 @@ class mmMapPlotCanvas(mmCanvas):
         event.ind is index into this array AFTER nan has been stripped.
         """
 
-        print 'mmMapPlotCanvas.onpick()', event.ind
+        print('mmMapPlotCanvas.onpick()', event.ind)
         ind = event.ind
         if not len(ind) >= 1:
             return
@@ -241,7 +241,7 @@ class mmMapPlotCanvas(mmCanvas):
         #runMapRow = int(yRunRow_noNan[ind[0]])
 
         sessIdx, stackdbIdx = self.myMapPlot.getUserSelection(ind[0])
-        print 'sessIdx:', sessIdx, 'stackdbIdx:', stackdbIdx
+        print('sessIdx:', sessIdx, 'stackdbIdx:', stackdbIdx)
 
         """
         sessIdx_noNan = self.sessIdx[~np.isnan(self.sessIdx)]
@@ -419,7 +419,7 @@ class mmStackPlotCanvas(mmCanvas):
         self.draw()
 
     def receiveevent(self, event):
-        print 'mmStackPlotCanvas.receiveevent()', event.type
+        print('mmStackPlotCanvas.receiveevent()', event.type)
         if event.map != self.map:
             return
         if event.mapSession != self.stateDict['sessidx']:
@@ -429,7 +429,7 @@ class mmStackPlotCanvas(mmCanvas):
             self.selectPoint(event.stackdbIdx)
 
     def onkey(self, event):
-        print 'mmStackPlotCanvas.onkey()', event.key
+        print('mmStackPlotCanvas.onkey()', event.key)
         super(mmStackPlotCanvas, self).onkey(event)
 
     def onpick(self, event):
@@ -439,7 +439,7 @@ class mmStackPlotCanvas(mmCanvas):
         event.ind: A list of hit points, just use the first.
         """
 
-        print 'mmStackPlotCanvas.onpick()', event.ind
+        print('mmStackPlotCanvas.onpick()', event.ind)
         ind = event.ind
         if not len(ind) >= 1:
             return
@@ -531,8 +531,8 @@ class mmStackCanvas(mmCanvas):
         Respond to clicks in a map, stack, and image plot.
         """
 
-        print 'mmStackCanvas.onpick()', event.ind
-        print '   ON PICK IS NOT WORKING FOR STACK IMAGE !!!!!'
+        print('mmStackCanvas.onpick()', event.ind)
+        print('   ON PICK IS NOT WORKING FOR STACK IMAGE !!!!!')
 
         """
         event.ind is a list of hit points, just use the first.
@@ -591,7 +591,7 @@ class mmStackCanvas(mmCanvas):
             self.draw()
 
     def receiveevent(self, event):
-        print 'mmStackPlotCanvas.receiveevent()', event.type
+        print('mmStackPlotCanvas.receiveevent()', event.type)
         if event.map != self.map:
             return
         if event.mapSession != self.stateDict['sessidx']:
@@ -628,7 +628,7 @@ class mmStackCanvas(mmCanvas):
         self.axes.set_xlabel('um')
         self.axes.set_ylabel('um')
 
-        print 'image is of type:', self.stack.images.dtype
+        print('image is of type:', self.stack.images.dtype)
 
         #
         #  line
@@ -722,7 +722,7 @@ class mmStackCanvas(mmCanvas):
                 self.yMasked = self.yPlot[~self.zMask.mask]
                 self.stackdbIdxMasked = self.stackdbIdx_plot[~self.zMask.mask]
             except:
-                print 'ERROR: mmStackCanvas.setSlice_'
+                print('ERROR: mmStackCanvas.setSlice_')
 
             # set_offsets must be passed an Nx2 array. Here we use np.c_[]
             self.myScatterPlot.set_offsets(np.c_[self.xMasked, self.yMasked])

--- a/PyQtMapManager/mmWindow.py
+++ b/PyQtMapManager/mmWindow.py
@@ -71,7 +71,7 @@ class mmWindow(QtGui.QMainWindow):
 
     def closeEvent(self, event):
         """On close, remove self from xxx list"""
-        print 'PlotWindow.closeEvent()'
+        print('PlotWindow.closeEvent()')
         self.parent.closechildwindow(self)
 
     def setStatus(self, str):
@@ -86,7 +86,7 @@ class mmWindow(QtGui.QMainWindow):
         self.parent.broadcastevent(event)
 
     def receiveevent(self, event):
-        print 'PlotWindow.receiveevent()', event.type
+        print('PlotWindow.receiveevent()', event.type)
         self.myCanvas.receiveevent(event)
 
 

--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -1,6 +1,6 @@
 numpy>=1.14.0
 pandas>=0.22.0
 requests>=2.18.4
-scipy>=1.0.0
+scipy<=1.2.0
 tifffile
 matplotlib

--- a/pymapmanager/mmStack.py
+++ b/pymapmanager/mmStack.py
@@ -9,7 +9,7 @@ import numpy as np
 
 # davis
 # was this, this import is failing ????
-#from scipy.misc import imsave
+from scipy.misc import imsave
 
 import tifffile
 #from skimage.io import imsave, imread
@@ -474,6 +474,6 @@ class mmStack():
 				#print('   mmStack.ingest() turn save back on')
 				#
 				# DAVIS REMOVED
-				#imsave(dstPath + dstFile, self.images[slice,:,:])
+				imsave(dstPath + dstFile, self.images[slice,:,:])
 
 			self._images = None

--- a/pymapmanager/version.py
+++ b/pymapmanager/version.py
@@ -6,5 +6,5 @@ Example::
 	import pymapmanager as pmm
 	pmm._version_
 """
-__version__ = '0.0.5'
+__version__ = '0.0.6'
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ requests>=2.18.4
 
 #re-added davis
 Pillow
-scipy>=1.0.0
+scipy<=1.2.0
 tifffile
 
 matplotlib

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
         "pandas>=0.22.0",
         "requests>=2.18.4",
         "pillow",
-        "scipy>=1.0.0",
+        "scipy<=1.2.0",
         "tifffile",
         "matplotlib"
     ]


### PR DESCRIPTION
`pip install pymapmanager` succeeds but the module can't be imported due to the error `ImportError: cannot import name 'imsave' from 'scipy.misc' `.

```
>>> import pymapmanager
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/vasudhajha/.pyenv/versions/cudmorelab3.7/lib/python3.7/site-packages/pymapmanager/__init__.py", line 12, in <module>
    from .mmMap import mmMap
  File "/Users/vasudhajha/.pyenv/versions/cudmorelab3.7/lib/python3.7/site-packages/pymapmanager/mmMap.py", line 14, in <module>
    from pymapmanager.mmStack import mmStack
  File "/Users/vasudhajha/.pyenv/versions/cudmorelab3.7/lib/python3.7/site-packages/pymapmanager/mmStack.py", line 9, in <module>
    from scipy.misc import imsave
ImportError: cannot import name 'imsave' from 'scipy.misc' (/Users/vasudhajha/.pyenv/versions/cudmorelab3.7/lib/python3.7/site-packages/scipy/misc/__init__.py)
>>>
```

It turns out that the dependency constraint https://github.com/cudmore/PyMapManager/blob/master/setup.py#L54 causes the installation of the latest version of scipy (1.7.3 at this time), which does not have imsave in scipy.misc anymore. I have updated setup.py to use `scipy<=1.2.0` and this fixes the issue with imsave.

Additionally, installing PyMapManager manually by running `python setup.py install` resulted in several SyntaxErrors. This pull request also fixes those errors. I have bumped the version from 0.0.5 to 0.0.6 so that a new release can be published to PyPI, then installation via pip will succeed and there will be no errors when importing pymapmanager.